### PR TITLE
add deamon dependency to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(
 	author_email="rliou92@gmail.com",
 	description="Manage monitor configuration automatically.",
 	url="https://github.com/rliou92/python-umonitor",
-
+	install_requires=[
+          'daemon',
+      ],
 	entry_points={
 		'console_scripts': [
 			'umonitor = umonitor:main',

--- a/setup_dev.py
+++ b/setup_dev.py
@@ -20,7 +20,9 @@ setup(
 	author_email="rliou92@gmail.com",
 	description="Manage monitor configuration automatically.",
 	url="https://github.com/rliou92/python-umonitor",
-
+	install_requires=[
+          'daemon',
+      ],
 	zip_safe=False
 
 )


### PR DESCRIPTION
umonitor command failes when 'daemon' is not installed.
Added dependecy to both setup files, manually tested on python 3.6 and 3.9

this is the error I get when dependency is missing

```
Traceback (most recent call last):
  File "/home/mundo/.pyenv/versions/3.9.0/bin/umonitor", line 33, in <module>
    sys.exit(load_entry_point('umonitor==20181018', 'console_scripts', 'umonitor')())
  File "/home/mundo/.pyenv/versions/3.9.0/bin/umonitor", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/home/mundo/.pyenv/versions/3.9.0/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/home/mundo/.pyenv/versions/3.9.0/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/mundo/.pyenv/versions/3.9.0/lib/python3.9/site-packages/umonitor/__init__.py", line 3, in <module>
    from umonitor.umonitor import Umonitor
  File "/home/mundo/.pyenv/versions/3.9.0/lib/python3.9/site-packages/umonitor/umonitor.py", line 9, in <module>
    import daemon
ModuleNotFoundError: No module named 'daemon'
```