### PR TITLE
Fix usage of '0' instead of '\x00'

### DIFF
--- a/umonitor/screen.pyx
+++ b/umonitor/screen.pyx
@@ -191,7 +191,7 @@ cdef class Screen:
 		for i in range(output_name_length):
 			output_name[i] = <char> output_name_raw[i]
 
-		output_name[output_name_length] = b'0'
+		output_name[output_name_length] = b'\x00'
 		logging.info("Output name %s" % output_name)
 		return output_name
 
@@ -230,7 +230,7 @@ cdef class Screen:
 		vendor[0] = <char> (sc + (edid[8] >> 2))
 		vendor[1] = <char> (sc + (((edid[8] & 0x03) << 3) | (edid[9] >> 5)))
 		vendor[2] = <char> (sc + (edid[9] & 0x1F))
-		vendor[3] = b'0'
+		vendor[3] = b'\x00'
 
 		# product = (edid[11] << 8) | edid[10];
 		# serial = edid[15] << 24 | edid[14] << 16 | edid[13] << 8 | edid[12];


### PR DESCRIPTION
Hey!
One of my monitors had a problem where the name wasn't identified correctly.
After a quick debug session, it seems b'0' was used to terminate display names instead of b'\x00'. 
`strlen` is used [immediately afterwards](https://github.com/rliou92/python-umonitor/blob/master/umonitor/screen.c#L2528), so whenever it worked so far it was because luckily a \x00 byte was at the right place at the right time.